### PR TITLE
⚡ Add state-preserving redirect feature

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -68,6 +68,7 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{
     String title = getParameter(request, "title", "");
     String text = getParameter(request, "text", "");
+    long maxComments = Long.parseLong(getParameter(request, "maxComments", ""));
     long timestamp = System.currentTimeMillis();
 
     Entity commentEntity = new Entity("Comment");
@@ -78,7 +79,9 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);
 
-    response.sendRedirect("/index.html");
+    response.sendRedirect(
+      String.format("/index.html?maxComments=%d", maxComments)
+    );
   }
 
   /**

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -178,9 +178,11 @@ const setMaxComments = (value) => {
   for (let option of maxCommentsElement.options) {
     optionValues.push(option.value);
   }
-  const index = optionValues.indexOf(value);
+  let index = optionValues.indexOf(value);
+  // .indexOf() will return -1 if the item is not present in the array
+  const notFound = -1;
   // if the passed value is not a valid option (not found in options array), set the value to 5
-  if (index === -1) {
+  if (index === notFound) {
     // option with value 5 is stored at index 0
     index = 0;
   }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -179,12 +179,10 @@ const setMaxComments = (value) => {
     optionValues.push(option.value);
   }
   const index = optionValues.indexOf(value);
-  // while -1 is a valid value for the value of the select element, 5 is the
-  // intended default. allowing all unknown values to be normalised to -1 would
-  // result in all comments being displayed for all unknown values. this also
-  // would apply to cases where no maxComments parameter is received.
+  // if the passed value is not a valid option (not found in options array), set the value to 5
   if (index === -1) {
-    index = 5;
+    // option with value 5 is stored at index 0
+    index = 0;
   }
   maxCommentsElement.selectedIndex = index;
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -191,6 +191,7 @@ window.onload = async () => {
   slowFillBiography();
   // retrieve the 'maxComments' GET parameter from the URL string
   // and use it to only load the requested number of comments on page load.
+  // by default, if no paramter is provided, maxComments is 5
   const maxComments = getParameter('maxComments') || '5';
   // set the value of the select element to the value supplied by the
   // GET parameter.

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -154,12 +154,48 @@ const selectionChangeHandler = async (value) => {
   loadComments(value);
 }
 
+/**
+ * Get a specific GET parameter from the query string
+ * @param{String} name The name of the parameter
+ */
+const getParameter = (name) => {
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
+  return urlParams.get(name);
+}
+
+/**
+ * Set the value of the #maxComments element on the page
+ * @param{Number} value The value to be assigned
+ */
+const setMaxComments = (value) => {
+  const maxCommentsElement = document.getElementById('maxComments');
+  const selectedIndex = maxCommentsElement.selectedIndex;
+  const optionValues = [];
+  // constructing the optionValues[] array in this way is required as
+  // maxCommentsElement.options is an HTMLCollection object, and does not
+  // have a .indexOf() function
+  for (let option of maxCommentsElement.options) {
+    optionValues.push(option.value);
+  }
+  const index = optionValues.indexOf(value);
+  // while -1 is a valid value for the value of the select element, 5 is the
+  // intended default. allowing all unknown values to be normalised to -1 would
+  // result in all comments being displayed for all unknown values. this also
+  // would apply to cases where no maxComments parameter is received.
+  if (index === -1) {
+    index = 5;
+  }
+  maxCommentsElement.selectedIndex = index;
+}
+
 window.onload = async () => {
   slowFillBiography();
   // retrieve the 'maxComments' GET parameter from the URL string
   // and use it to only load the requested number of comments on page load.
-  const queryString = window.location.search;
-  const urlParams = new URLSearchParams(queryString);
-  const maxComments = urlParams.get('maxComments') || '-1';
-  loadComments(maxComments);
+  const maxComments = getParameter('maxComments') || '5';
+  // set the value of the select element to the value supplied by the
+  // GET parameter.
+  setMaxComments(maxComments);
+  selectionChangeHandler(maxComments);
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -171,10 +171,10 @@ const getParameter = (name) => {
 const setMaxComments = (value) => {
   const maxCommentsElement = document.getElementById('maxComments');
   const selectedIndex = maxCommentsElement.selectedIndex;
-  const optionValues = [];
   // constructing the optionValues[] array in this way is required as
   // maxCommentsElement.options is an HTMLCollection object, and does not
   // have a .indexOf() function
+  const optionValues = [];
   for (let option of maxCommentsElement.options) {
     optionValues.push(option.value);
   }


### PR DESCRIPTION
### Change List:
* Submitting a comment will no longer result in the page reloading with the default number of visible comments. Now, the page will reload with the same number of visible comments as had been set when the form was posted, with the updated comment at the top of the list.

### Before:
#### Posting Comment
![image](https://user-images.githubusercontent.com/31371331/88058645-aa6db380-cb5b-11ea-92c7-583acd286a34.png)
#### After Posting
![image](https://user-images.githubusercontent.com/31371331/88058697-bf4a4700-cb5b-11ea-8958-49de008f18f3.png)

**As can be seen from the above, the page was reloaded, but the number of comments being displayed changes on reload**


### After:
#### Posting Comment
![image](https://user-images.githubusercontent.com/31371331/88058893-020c1f00-cb5c-11ea-9365-a5df25dd3549.png)
#### After Posting
![image](https://user-images.githubusercontent.com/31371331/88058994-249e3800-cb5c-11ea-8b36-014afd33c4e8.png)

**As can be seen from the above, the page now reloads and will display the same number of comments as had been visible before posting, with the posted comment now displayed as the top comment**