### PR TITLE
🐛  Fix maxComments handling

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -70,7 +70,6 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{
     String title = getParameter(request, "title", "");
     String text = getParameter(request, "text", "");
-    long maxComments = Long.parseLong(getParameter(request, "maxComments", ""));
     long timestamp = System.currentTimeMillis();
     
     /* 
@@ -96,9 +95,7 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);
 
-    response.sendRedirect(
-      String.format("/index.html?maxComments=%d", maxComments)
-    );
+    response.sendRedirect("/index.html");
   }
 
   /**

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -34,10 +34,6 @@
     <form action="/comments" method="POST">
       <span>Type your comment here!</span>
       <input name="text" type="text">
-      <!-- hidden input element used to shadow select
-          element with id #maxComments -->
-      <input name="maxComments" type="hidden"
-          id="hiddenMaxComments">
     </form>
     <div id="comments">
     </div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -146,25 +146,10 @@ const loadComments = async (maxComments) => {
  * @param{Number} value The current value of the select element
  */
 const selectionChangeHandler = async (value) => {
-  // #hiddenMaxComments is a hidden input entry in the form on the home page.
-  // it is a shadow of the select element, and is submitted along with the form.
-  // it will be used in the functionality of a later update.
-  const formMaxCommentsElement = document.getElementById('hiddenMaxComments');
-  formMaxCommentsElement.value = value;
-
-  // once #hiddenMaxComments has been updated, reload the comments according to
-  // the updated value of the select element
+  // update the value of maxComments in the session storage,
+  // and reload the comments according to the updated value
+  sessionStorage.setItem('maxComments', value);
   loadComments(value);
-}
-
-/**
- * Get a specific GET parameter from the query string
- * @param{String} name The name of the parameter
- */
-const getParameter = (name) => {
-  const queryString = window.location.search;
-  const urlParams = new URLSearchParams(queryString);
-  return urlParams.get(name);
 }
 
 /**
@@ -190,14 +175,14 @@ const setMaxComments = (value) => {
     index = 0;
   }
   maxCommentsElement.selectedIndex = index;
+  sessionStorage.setItem('maxComments', maxCommentsElement[index]);
 }
 
 window.onload = async () => {
   slowFillBiography();
-  // retrieve the 'maxComments' GET parameter from the URL string
-  // and use it to only load the requested number of comments on page load.
-  // by default, if no paramter is provided, maxComments is 5
-  const maxComments = getParameter('maxComments') || '5';
+  // retrieve the 'maxComments' value from sessionStorage if a value
+  // has been set. if not, set maxComments to 5
+  const maxComments = sessionStorage.getItem('maxComments') || '5';
   // set the value of the select element to the value supplied by the
   // GET parameter.
   setMaxComments(maxComments);


### PR DESCRIPTION
### Change List:
* Remove redundant hidden form element tracking the value of maxComments
* Remove redundant maxComments parameter handling from POST route
* Refactor maxComments handling in index.js to use sessionStorage, so that the value of maxComments will persist until the tab is closed