### PR TITLE
⚡ Image deletion feature

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -22,14 +22,14 @@ public final class Comment {
   private final String text;
   private final long timestamp;
   private final String imageURL;
-  private final long imageBlobstoreKey;
+  private final String imageBlobstoreKey;
 
-  public Comment(long id, String title, String text, long timestamp, String imageURL, long imageBlobstoreKey) {
+  public Comment(long id, String title, String text, long timestamp, String imageURL, String imageBlobstoreKey) {
     this.id = id;
     this.title = title;
     this.text = text;
-    this.imageURL = imageURL;
     this.timestamp = timestamp;
+    this.imageURL = imageURL;
     this.imageBlobstoreKey = imageBlobstoreKey;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -58,7 +58,7 @@ import javax.servlet.http.HttpServletResponse;
  * The response body will be encoded as json.
  * The response body will contain a single top-level array, whose
  * elements will all be Comment objects.
- * Comment objects have five members:
+ * Comment objects have the following members:
  *   id: the id of the comment in the server's datastore
  *   title: the comment title
  *   text: the comment text

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -57,10 +57,12 @@ import javax.servlet.http.HttpServletResponse;
  * The response body will be encoded as json.
  * The response body will contain a single top-level array, whose
  * elements will all be Comment objects.
- * Comment objects have three members:
+ * Comment objects have five members:
  *   id: the id of the comment in the server's datastore
  *   title: the comment title
  *   text: the comment text
+ *   timestamp: the comment creation time
+ *   imageBlobstoreKey: the key of the comment image in BlobStore
  *
  * POST:
  * The request body must contain:
@@ -98,7 +100,7 @@ public class DataServlet extends HttpServlet {
       String text = (String) entity.getProperty("text");
       long timestamp = (long) entity.getProperty("timestamp");
       String imageURL = (String) entity.getProperty("imageURL");
-      long imageBlobstoreKey = (long) entity.getProperty("imageBlobstoreKey");
+      String imageBlobstoreKey = (String) entity.getProperty("imageBlobstoreKey");
 
       Comment comment = new Comment(id, title, text, timestamp, imageURL, imageBlobstoreKey);
       comments.add(comment);
@@ -114,8 +116,8 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{
     String title = getParameter(request, "title", "");
     String text = getParameter(request, "text", "");
-    String imageURL = getUploadedFileUrl(request, "imageURL");
     long timestamp = System.currentTimeMillis();
+    String imageURL = getUploadedFileUrl(request, "imageURL");
     
     /* 
      * \\s represents any whitespace character
@@ -144,7 +146,7 @@ public class DataServlet extends HttpServlet {
     // if a file was uploaded
     if( blobKeys != null && !blobKeys.isEmpty() ) {
       // the form only contains a single file input, so get the first key
-      blobKey = blobKeys.get(0).toString();
+      blobKey = blobKeys.get(0).getKeyString();
     }
 
     Entity commentEntity = new Entity("Comment");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -139,7 +139,6 @@ public class DataServlet extends HttpServlet {
       response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }
 
-    /* Open a connection to blobstore */
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
     /* Get a list of all files uploaded to blobstore from this request */
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);

--- a/portfolio/src/main/java/com/google/sps/servlets/DeletionServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeletionServlet.java
@@ -14,6 +14,9 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Key;
@@ -49,12 +52,15 @@ public class DeletionServlet extends HttpServlet {
         gson.fromJson(bodyString, DeletionRequestBody.class);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    BlobstoreService blobstore = BlobstoreServiceFactory.getBlobstoreService();
 
     // each key has a unique id associated with it
     // this id can be used to reconstruct the key using .createKey()
     Key key = KeyFactory.createKey("Comment", body.getId());
+    BlobKey blobKey = new BlobKey(body.getImageBlobstoreKey());
 
     datastore.delete(key);
+    blobstore.delete(blobKey);
   }
 
   /**
@@ -75,13 +81,22 @@ public class DeletionServlet extends HttpServlet {
   private class DeletionRequestBody {
     // the only parameter in the body is the id of the comment to be deleted
     private long id;
+    private String imageBlobstoreKey;
 
     public long getId() {
       return this.id;
     }
 
+    public String getImageBlobstoreKey() {
+        return this.imageBlobstoreKey;
+    }
+
     public String toString() {
-      return String.format("DeletionRequestBody{ id=\"%d\" }", this.id);
+      return String.format(
+          "DeletionRequestBody{ id=\"%d\", imageBlobstoreKey = %s }",
+          this.id,
+          this.imageBlobstoreKey
+      );
     }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeletionServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeletionServlet.java
@@ -59,14 +59,22 @@ public class DeletionServlet extends HttpServlet {
 
     // Initialise a connection to DataStore.
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    BlobstoreService blobstore = BlobstoreServiceFactory.getBlobstoreService();
 
     // Each key has a unique id associated with it.
     // This id can be used to reconstruct the key using .createKey()
     Key key = KeyFactory.createKey("Comment", body.getId());
-    BlobKey blobKey = new BlobKey(body.getImageBlobstoreKey());
 
     datastore.delete(key);
+
+    // Initialise a connection to Blobstore
+    BlobstoreService blobstore = BlobstoreServiceFactory.getBlobstoreService();
+
+    // Create a BlobKey from the provided BlobKey String
+    // In case of an invalid or non-existent BlobKey, the servlet will quit.
+    // This is expected, as some comments don't have images but should still
+    // be viable for deletion.
+    BlobKey blobKey = new BlobKey(body.getImageBlobstoreKey());
+
     blobstore.delete(blobKey);
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeletionServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeletionServlet.java
@@ -105,13 +105,5 @@ public class DeletionServlet extends HttpServlet {
     public String getImageBlobstoreKey() {
         return this.imageBlobstoreKey;
     }
-
-    public String toString() {
-      return String.format(
-          "DeletionRequestBody{ id=\"%d\", imageBlobstoreKey = %s }",
-          this.id,
-          this.imageBlobstoreKey
-      );
-    }
   }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -188,8 +188,12 @@ const loadComments = async (maxComments) => {
       // the client must wait for confirmation of comment deletion
       // before proceeding to refresh comments, otherwise client will
       // fall out of sync with the server
-      await deleteComment(comment.id, comment.imageBlobstoreKey);
-      refreshComments();
+      const response = await deleteComment(comment.id, comment.imageBlobstoreKey);
+      if ( !response.ok ) {
+        alert('Your comment could not be deleted. Please refresh the page and try again.');
+      } else {
+        refreshComments();
+      }
     };
   });
 };

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -188,11 +188,11 @@ const loadComments = async (maxComments) => {
       // the client must wait for confirmation of comment deletion
       // before proceeding to refresh comments, otherwise client will
       // fall out of sync with the server
-      await deleteComment(comment.id);
+      await deleteComment(comment.id, comment.imageBlobstoreKey);
       refreshComments();
-    }
+    };
   });
-}
+};
 
 /**
  * Load the URL for uploading of the comment form.
@@ -217,9 +217,10 @@ const loadFormAction = async () => {
 /**
  * Send a POST request to the server, to delete a comment.
  * @param {number|string} id id of the comment to delete
+ * @param {string} imageBlobstoreKey blobstore key of the comment image
  */
-const deleteComment = async (id) => {
-  const data = {'id': id};
+const deleteComment = async (id, imageBlobstoreKey) => {
+  const data = {'id': id, 'imageBlobstoreKey': imageBlobstoreKey};
   const request = {
     method: 'POST',
     body: JSON.stringify(data)
@@ -282,6 +283,7 @@ const setMaxComments = (value) => {
 
 window.onload = async () => {
   slowFillBiography();
+  loadFormAction();
   // retrieve the 'maxComments' value from sessionStorage if a value
   // has been set. if not, set maxComments to 5
   const maxComments = sessionStorage.getItem('maxComments') || '5';


### PR DESCRIPTION
### Change List:
* Deleting a comment on the home page will now also delete the image in that comment from blobstore. Previously, a comment's image would persist after the deletion of the comment.
* /delete-comment API now expects 2 parameters: the DataStore id of the comment to be deleted, and the BlobStore key of the image associate with this comment

**No relevant UI changes**
