### PR TITLE
➖ ImageService removal

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -21,15 +21,13 @@ public final class Comment {
   private final String title;
   private final String text;
   private final long timestamp;
-  private final String imageURL;
   private final String imageBlobstoreKey;
 
-  public Comment(long id, String title, String text, long timestamp, String imageURL, String imageBlobstoreKey) {
+  public Comment(long id, String title, String text, long timestamp, String imageBlobstoreKey) {
     this.id = id;
     this.title = title;
     this.text = text;
     this.timestamp = timestamp;
-    this.imageURL = imageURL;
     this.imageBlobstoreKey = imageBlobstoreKey;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ImageLoadServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ImageLoadServlet.java
@@ -24,6 +24,18 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * The /image-load route exposes a simple API.
+ * This API can be accessed by the GET http method only.
+ *
+ * GET:
+ * The request body must contain:
+ *   - an 'imageBlobstoreKey' parameter
+ * The 'imageBlobstoreKey' parameter is used to identify the image
+ * which is to be sent back in the response.
+ * The response body will contain the image requested.
+ */
+
 /** Servlet that returns a programmable number of comments */
 @WebServlet("/image-load")
 public class ImageLoadServlet extends HttpServlet {

--- a/portfolio/src/main/java/com/google/sps/servlets/ImageLoadServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ImageLoadServlet.java
@@ -1,0 +1,57 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.gson.Gson;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that returns a programmable number of comments */
+@WebServlet("/image-load")
+public class ImageLoadServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String key = getParameter(request, "imageBlobstoreKey", "");
+    if ( key.equals("") ) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    BlobKey blobKey = new BlobKey(key);
+
+    // open a connection to blobstore
+    BlobstoreService blobstore = BlobstoreServiceFactory.getBlobstoreService();
+
+    blobstore.serve(blobKey, response);
+  }
+
+  /**
+   * @return the request parameter, or the default value if the parameter
+   *         was not specified by the client
+   */
+  private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+    String value = request.getParameter(name);
+    if (value == null) {
+      return defaultValue;
+    }
+    return value;
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/ImageLoadServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ImageLoadServlet.java
@@ -36,7 +36,7 @@ import javax.servlet.http.HttpServletResponse;
  * The response body will contain the image requested.
  */
 
-/** Servlet that returns a programmable number of comments */
+/** Servlet that returns the image associated with a BlobKey */
 @WebServlet("/image-load")
 public class ImageLoadServlet extends HttpServlet {
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -179,7 +179,9 @@ const loadComments = async (maxComments) => {
     div.id = comment.id;
     /* If the comment has a title, display it, else use the default message */
     title.innerText = comment.title || 'This comment does not have a title';
-    commentImage.src = comment.imageURL;
+    loadCommentImage(comment.imageBlobstoreKey).then((url) => {
+      commentImage.src = url;
+    });
     paragraph.innerText = comment.text;
     timestamp.innerText = new Date(comment.timestamp).toLocaleString();
     trashImage.src = '/images/trash.png';
@@ -212,6 +214,24 @@ const loadFormAction = async () => {
   const formElement = document.getElementById('comment-form');
   /* Set the comment form to upload to the route provided by BlobStore */
   formElement.action = url;
+};
+
+/**
+ * Returns a URL pointing to a comment's image.
+ * @param {string} imageBlobstoreKey The blobstore key of the image to be
+ * loaded.
+ */
+const loadCommentImage = async (imageBlobstoreKey) => {
+  // request the image from the image load servlet.
+  const response = await fetch(
+      `/image-load?imageBlobstoreKey=${imageBlobstoreKey}`
+  );
+  // extract the blob from the response. this blob will be the comment image.
+  const blob = await response.blob();
+  // store the blob locally in the browser's storage, and create a URL pointing
+  // to this local resource.
+  const imageURL = window.URL.createObjectURL(blob);
+  return imageURL;
 };
 
 /**


### PR DESCRIPTION
### Change List:
* ImageService is no longer used to serve images. Blobs are served directly from BlobStore and then handled on the frontend. This was done to remove the dependency on ImageService, as the library was not compatible with running on a live server on gcloud.
* Add /image-load API to serve blobs directly from BlobStore. The client is now responsible for decoding the blob and displaying it to the user.